### PR TITLE
Jerry_hu/re-attach-existing-dashboard-widget

### DIFF
--- a/dist/dashboard.d.ts
+++ b/dist/dashboard.d.ts
@@ -54,7 +54,9 @@ export type ChatRoom = {
  * Callbridge Dashboard.
  */
 export default class Dashboard extends Widget<{
-    'dashboard.READY': void;
+    'dashboard.READY': {
+        existing?: boolean;
+    };
     'dashboard.NAVIGATE': {
         service: Service;
         pathname: string;

--- a/dist/dashboard.d.ts
+++ b/dist/dashboard.d.ts
@@ -98,4 +98,11 @@ export default class Dashboard extends Widget<{
      * @param options Optional, service options.
      */
     load(service: Service, options?: ServiceOptions): void;
+    /**
+     * Loads a specific page from the session history.
+     * @param delta The position in the history to which you want to move,
+     * relative to the current page. A negative value moves backwards,
+     * a positive value moves forwards.
+     */
+    go(delta: number): void;
 }

--- a/dist/dashboard.js
+++ b/dist/dashboard.js
@@ -70,5 +70,14 @@ class Dashboard extends widget_1.default {
     load(service, options = {}) {
         this._send('dashboard', 'load', Object.assign({ service }, options));
     }
+    /**
+     * Loads a specific page from the session history.
+     * @param delta The position in the history to which you want to move,
+     * relative to the current page. A negative value moves backwards,
+     * a positive value moves forwards.
+     */
+    go(delta) {
+        this._send('dashboard', 'go', { delta });
+    }
 }
 exports.default = Dashboard;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,5 @@
 export { WidgetOptions } from './widget';
-export { default as Dashboard, Service, LayoutOption, ServiceOptions, } from './dashboard';
+export { default as Dashboard, Service, LayoutOption, ServiceOptions, ChatRoom, } from './dashboard';
 export { AudioSettings } from './room';
 export { default as Meeting, MeetingOptions } from './meeting';
 export { default as Livestream, LivestreamOptions } from './livestream';

--- a/dist/widget.d.ts
+++ b/dist/widget.d.ts
@@ -7,7 +7,7 @@ export type WidgetOptions = {
      * Supports attached or detached DOM element, document selector, or `window` (new tab).
      * If the element is detached, it will be set to invisible and attached to the main document.
      */
-    container: Window | HTMLElement | string | null;
+    container: Window | HTMLElement | string;
     /**
      * The Callbridge domain of the user.
      */
@@ -41,6 +41,11 @@ export type WidgetOptions = {
          * Whether to close the popup when the meeting is over.
          */
         autoClose?: boolean;
+        /**
+         * Whether to wait (up to 1.5 sec) for the existing widget.
+         * Requires a matching "window target name".
+         */
+        checkExisting?: boolean;
     };
 };
 type EventMap = Record<string, any>;
@@ -62,7 +67,7 @@ export default class Widget<T extends EventMap | {
     'widget.ERROR': string;
 }> implements WidgetEventEmitter<T> {
     private emitter;
-    constructor({ container, domain, sso, target: { name, features } }: WidgetOptions, autoLoad?: boolean);
+    constructor({ container, domain, sso, target: { name, features, checkExisting }, }: WidgetOptions, autoLoad?: boolean);
     /**
      * Unloads the widget by removing the iframe or close the tab/window.
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iotum/callbridge-js",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@iotum/callbridge-js",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0"
@@ -101,9 +101,9 @@
       "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3250,9 +3250,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4206,9 +4206,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4921,9 +4921,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5182,9 +5182,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
@@ -5563,9 +5563,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5760,9 +5760,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -5804,9 +5804,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -8106,9 +8106,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -8843,9 +8843,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9353,9 +9353,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -9553,9 +9553,9 @@
       }
     },
     "tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
@@ -9811,9 +9811,9 @@
       }
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iotum/callbridge-js",
   "description": "Loading wrapper for Callbridge",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Iotum (https://www.iotum.com)",
   "license": "MIT",
   "homepage": "https://www.callbridge.com/",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "build": "tsc",
     "test": "jest",
     "doc": "typedoc --plugin typedoc-plugin-markdown --plugin typedoc-plugin-missing-exports --out wiki --excludeExternals --internalModule _internal --readme none src/index.ts",
-    "predeploy": "npm install && npm run lint && npm run test && npm run doc && npm run build"
+    "predeploy": "npm install && npm run lint && npm run test && npm run build"
   }
 }

--- a/src/__tests__/dashboard-test.ts
+++ b/src/__tests__/dashboard-test.ts
@@ -105,4 +105,19 @@ describe('dashboard', () => {
     const redirectUrl = searchParams.get('redirect_url');
     expect(redirectUrl).toBe(`/conf/loading?events=true`);
   });
+
+  it('can navigate the history', () => {
+    dashboard = new Dashboard({ container, domain }, service);
+
+    dashboard.go(-2);
+
+    expect(dashboard.wnd?.postMessage).toHaveBeenCalledWith(
+      {
+        type: 'dashboard',
+        action: 'go',
+        delta: -2,
+      },
+      '*',
+    );
+  });
 });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -60,7 +60,9 @@ export type ChatRoom = {
  * Callbridge Dashboard.
  */
 export default class Dashboard extends Widget<{
-  'dashboard.READY': void;
+  'dashboard.READY': {
+    existing?: boolean;
+  };
   'dashboard.NAVIGATE': {
     service: Service;
     pathname: string;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -120,4 +120,14 @@ export default class Dashboard extends Widget<{
   load(service: Service, options: ServiceOptions = {}) {
     this._send('dashboard', 'load', { service, ...options });
   }
+
+  /**
+   * Loads a specific page from the session history.
+   * @param delta The position in the history to which you want to move,
+   * relative to the current page. A negative value moves backwards,
+   * a positive value moves forwards.
+   */
+  go(delta: number) {
+    this._send('dashboard', 'go', { delta });
+  }
 }

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -45,7 +45,7 @@ Audio output settings.
 
 #### Defined in
 
-[room.ts:6](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L6)
+[room.ts:6](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L6)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[dashboard.ts:46](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L46)
+[dashboard.ts:46](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L46)
 
 ___
 
@@ -83,7 +83,7 @@ Livestream options.
 
 #### Defined in
 
-[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/2066c52/src/livestream.ts#L6)
+[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/5b639d5/src/livestream.ts#L6)
 
 ___
 
@@ -114,7 +114,7 @@ Meeting options.
 
 #### Defined in
 
-[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/2066c52/src/meeting.ts#L7)
+[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/5b639d5/src/meeting.ts#L7)
 
 ___
 
@@ -133,7 +133,7 @@ Dashboard service options.
 
 #### Defined in
 
-[dashboard.ts:34](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L34)
+[dashboard.ts:34](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L34)
 
 ___
 
@@ -147,16 +147,17 @@ Widget options.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `container` | `Window` \| `HTMLElement` \| `string` \| ``null`` | The container for the widget. Supports attached or detached DOM element, document selector, or `window` (new tab). If the element is detached, it will be set to invisible and attached to the main document. |
+| `container` | `Window` \| `HTMLElement` \| `string` | The container for the widget. Supports attached or detached DOM element, document selector, or `window` (new tab). If the element is detached, it will be set to invisible and attached to the main document. |
 | `domain` | `string` | The Callbridge domain of the user. |
 | `sso?` | { `hostId?`: `number` ; `token?`: `string`  } | Optional, Single Sign-On |
 | `sso.hostId?` | `number` | Optional account number of the user. |
 | `sso.token?` | `string` | Optional host-specific authorization token. |
-| `target?` | { `autoClose?`: `boolean` ; `features?`: `string` ; `name?`: `string`  } | Optional, options for `window.open` when `container` is `window`. **`See`** [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open). |
+| `target?` | { `autoClose?`: `boolean` ; `checkExisting?`: `boolean` ; `features?`: `string` ; `name?`: `string`  } | Optional, options for `window.open` when `container` is `window`. **`See`** [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open). |
 | `target.autoClose?` | `boolean` | Whether to close the popup when the meeting is over. |
+| `target.checkExisting?` | `boolean` | Whether to wait (up to 1.5 sec) for the existing widget. Requires a matching "window target name". |
 | `target.features?` | `string` | The window features. |
 | `target.name?` | `string` | The window target name. |
 
 #### Defined in
 
-[widget.ts:6](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L6)
+[widget.ts:9](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L9)

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -45,7 +45,7 @@ Audio output settings.
 
 #### Defined in
 
-[room.ts:6](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L6)
+[room.ts:6](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L6)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[dashboard.ts:46](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L46)
+[dashboard.ts:46](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L46)
 
 ___
 
@@ -83,7 +83,7 @@ Livestream options.
 
 #### Defined in
 
-[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/5b639d5/src/livestream.ts#L6)
+[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/livestream.ts#L6)
 
 ___
 
@@ -114,7 +114,7 @@ Meeting options.
 
 #### Defined in
 
-[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/5b639d5/src/meeting.ts#L7)
+[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/meeting.ts#L7)
 
 ___
 
@@ -133,7 +133,7 @@ Dashboard service options.
 
 #### Defined in
 
-[dashboard.ts:34](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L34)
+[dashboard.ts:34](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L34)
 
 ___
 
@@ -160,4 +160,4 @@ Widget options.
 
 #### Defined in
 
-[widget.ts:9](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L9)
+[widget.ts:9](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L9)

--- a/wiki/classes/Dashboard.md
+++ b/wiki/classes/Dashboard.md
@@ -6,7 +6,7 @@ Callbridge Dashboard.
 
 ## Hierarchy
 
-- [`default`](internal.default.md)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\>
+- [`default`](internal.default.md)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\>
 
   ↳ **`Dashboard`**
 
@@ -53,7 +53,7 @@ Callbridge Dashboard.
 
 #### Defined in
 
-[dashboard.ts:84](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L84)
+[dashboard.ts:86](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L86)
 
 ## Accessors
 
@@ -73,7 +73,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:235](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L235)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
 
 ___
 
@@ -93,7 +93,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:228](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L228)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
 
 ___
 
@@ -113,7 +113,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:242](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L242)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
 
 ## Methods
 
@@ -129,14 +129,14 @@ Returns true if the event had listeners, false otherwise.
 
 | Name | Type |
 | :------ | :------ |
-| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
+| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `eventName` | `K` |
-| `data?` | { `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`] |
+| `data?` | { `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`] |
 
 #### Returns
 
@@ -148,7 +148,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:281](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L281)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
 
 ___
 
@@ -171,7 +171,7 @@ Loads the service.
 
 #### Defined in
 
-[dashboard.ts:118](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L118)
+[dashboard.ts:120](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L120)
 
 ___
 
@@ -185,14 +185,14 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 | Name | Type |
 | :------ | :------ |
-| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
+| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `eventName` | `K` |
-| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
+| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
 
 #### Returns
 
@@ -204,7 +204,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L262)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
 
 ___
 
@@ -218,14 +218,14 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 | Name | Type |
 | :------ | :------ |
-| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
+| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `eventName` | `K` |
-| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
+| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
 
 #### Returns
 
@@ -237,7 +237,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:254](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L254)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
 
 ___
 
@@ -252,14 +252,14 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 | Name | Type |
 | :------ | :------ |
-| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
+| `K` | extends [`EventKey`](../modules/internal.md#eventkey)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }\> |
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `eventName` | `K` |
-| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: `void` ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
+| `listener` | [`Listener`](../modules/internal.md#listener)<{ `dashboard.NAVIGATE`: { `hash`: `string` ; `pathname`: `string` ; `search`: `string` ; `service`: [`Service`](../enums/Service.md)  } ; `dashboard.READY`: { `existing?`: `boolean`  } ; `dashboard.ROOM_LIST`: { `channels`: { `[channelId: string]`: [`ChatRoom`](../README.md#chatroom);  } ; `rooms`: { `[roomId: string]`: [`ChatRoom`](../README.md#chatroom);  }  } ; `dashboard.UNREAD_MESSAGES`: { `rooms`: { `[id: string]`: `number`;  }  }  }[`K`]\> |
 
 #### Returns
 
@@ -271,7 +271,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:271](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L271)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
 
 ___
 
@@ -300,7 +300,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L291)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
 
 ___
 
@@ -328,7 +328,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:219](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L219)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
 
 ___
 
@@ -348,4 +348,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:195](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L195)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)

--- a/wiki/classes/Dashboard.md
+++ b/wiki/classes/Dashboard.md
@@ -25,6 +25,7 @@ Callbridge Dashboard.
 ### Methods
 
 - [emit](Dashboard.md#emit)
+- [go](Dashboard.md#go)
 - [load](Dashboard.md#load)
 - [off](Dashboard.md#off)
 - [on](Dashboard.md#on)
@@ -53,7 +54,7 @@ Callbridge Dashboard.
 
 #### Defined in
 
-[dashboard.ts:86](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L86)
+[dashboard.ts:86](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L86)
 
 ## Accessors
 
@@ -73,7 +74,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L255)
 
 ___
 
@@ -93,7 +94,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L248)
 
 ___
 
@@ -113,7 +114,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L262)
 
 ## Methods
 
@@ -148,7 +149,29 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L301)
+
+___
+
+### go
+
+▸ **go**(`delta`): `void`
+
+Loads a specific page from the session history.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `delta` | `number` | The position in the history to which you want to move, relative to the current page. A negative value moves backwards, a positive value moves forwards. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[dashboard.ts:130](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L130)
 
 ___
 
@@ -171,7 +194,7 @@ Loads the service.
 
 #### Defined in
 
-[dashboard.ts:120](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L120)
+[dashboard.ts:120](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L120)
 
 ___
 
@@ -204,7 +227,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L282)
 
 ___
 
@@ -237,7 +260,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L274)
 
 ___
 
@@ -271,7 +294,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L291)
 
 ___
 
@@ -300,7 +323,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L311)
 
 ___
 
@@ -328,7 +351,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L239)
 
 ___
 
@@ -348,4 +371,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L214)

--- a/wiki/classes/Livestream.md
+++ b/wiki/classes/Livestream.md
@@ -52,7 +52,7 @@ Callbridge Livesteam Viewer.
 
 #### Defined in
 
-[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/5b639d5/src/livestream.ts#L28)
+[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/livestream.ts#L28)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L255)
 
 ___
 
@@ -92,7 +92,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L248)
 
 ___
 
@@ -112,7 +112,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L262)
 
 ## Methods
 
@@ -147,7 +147,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L301)
 
 ___
 
@@ -180,7 +180,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L282)
 
 ___
 
@@ -213,7 +213,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L274)
 
 ___
 
@@ -247,7 +247,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L291)
 
 ___
 
@@ -276,7 +276,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L311)
 
 ___
 
@@ -304,7 +304,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L239)
 
 ___
 
@@ -324,4 +324,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L214)

--- a/wiki/classes/Livestream.md
+++ b/wiki/classes/Livestream.md
@@ -52,7 +52,7 @@ Callbridge Livesteam Viewer.
 
 #### Defined in
 
-[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/2066c52/src/livestream.ts#L28)
+[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/5b639d5/src/livestream.ts#L28)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:235](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L235)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
 
 ___
 
@@ -92,7 +92,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:228](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L228)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
 
 ___
 
@@ -112,7 +112,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:242](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L242)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
 
 ## Methods
 
@@ -147,7 +147,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:281](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L281)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
 
 ___
 
@@ -180,7 +180,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L262)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
 
 ___
 
@@ -213,7 +213,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:254](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L254)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
 
 ___
 
@@ -247,7 +247,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:271](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L271)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
 
 ___
 
@@ -276,7 +276,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L291)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
 
 ___
 
@@ -304,7 +304,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:219](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L219)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
 
 ___
 
@@ -324,4 +324,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:195](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L195)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)

--- a/wiki/classes/Meeting.md
+++ b/wiki/classes/Meeting.md
@@ -61,7 +61,7 @@ Callbridge Meeting Room.
 
 #### Defined in
 
-[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/2066c52/src/meeting.ts#L71)
+[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/5b639d5/src/meeting.ts#L71)
 
 ## Accessors
 
@@ -81,7 +81,7 @@ Room.instance
 
 #### Defined in
 
-[widget.ts:235](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L235)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
 
 ___
 
@@ -101,7 +101,7 @@ Room.isReady
 
 #### Defined in
 
-[widget.ts:228](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L228)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
 
 ___
 
@@ -121,7 +121,7 @@ Room.wnd
 
 #### Defined in
 
-[widget.ts:242](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L242)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
 
 ## Methods
 
@@ -148,7 +148,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:158](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L158)
+[room.ts:158](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L158)
 
 ___
 
@@ -183,7 +183,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:281](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L281)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
 
 ___
 
@@ -209,7 +209,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:147](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L147)
+[room.ts:147](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L147)
 
 ___
 
@@ -242,7 +242,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L262)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
 
 ___
 
@@ -275,7 +275,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:254](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L254)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
 
 ___
 
@@ -309,7 +309,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:271](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L271)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
 
 ___
 
@@ -338,7 +338,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L291)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
 
 ___
 
@@ -364,7 +364,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:89](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L89)
+[room.ts:89](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L89)
 
 ___
 
@@ -390,7 +390,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:97](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L97)
+[room.ts:97](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L97)
 
 ___
 
@@ -416,7 +416,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:105](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L105)
+[room.ts:105](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L105)
 
 ___
 
@@ -442,7 +442,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:121](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L121)
+[room.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L121)
 
 ___
 
@@ -468,7 +468,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:113](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L113)
+[room.ts:113](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L113)
 
 ___
 
@@ -494,7 +494,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:81](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L81)
+[room.ts:81](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L81)
 
 ___
 
@@ -520,7 +520,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:132](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L132)
+[room.ts:132](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L132)
 
 ___
 
@@ -548,7 +548,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:219](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L219)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
 
 ___
 
@@ -568,4 +568,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:195](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L195)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)

--- a/wiki/classes/Meeting.md
+++ b/wiki/classes/Meeting.md
@@ -61,7 +61,7 @@ Callbridge Meeting Room.
 
 #### Defined in
 
-[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/5b639d5/src/meeting.ts#L71)
+[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/meeting.ts#L71)
 
 ## Accessors
 
@@ -81,7 +81,7 @@ Room.instance
 
 #### Defined in
 
-[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L255)
 
 ___
 
@@ -101,7 +101,7 @@ Room.isReady
 
 #### Defined in
 
-[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L248)
 
 ___
 
@@ -121,7 +121,7 @@ Room.wnd
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L262)
 
 ## Methods
 
@@ -148,7 +148,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:158](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L158)
+[room.ts:158](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L158)
 
 ___
 
@@ -183,7 +183,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L301)
 
 ___
 
@@ -209,7 +209,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:147](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L147)
+[room.ts:147](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L147)
 
 ___
 
@@ -242,7 +242,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L282)
 
 ___
 
@@ -275,7 +275,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L274)
 
 ___
 
@@ -309,7 +309,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L291)
 
 ___
 
@@ -338,7 +338,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L311)
 
 ___
 
@@ -364,7 +364,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:89](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L89)
+[room.ts:89](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L89)
 
 ___
 
@@ -390,7 +390,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:97](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L97)
+[room.ts:97](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L97)
 
 ___
 
@@ -416,7 +416,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:105](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L105)
+[room.ts:105](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L105)
 
 ___
 
@@ -442,7 +442,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L121)
+[room.ts:121](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L121)
 
 ___
 
@@ -468,7 +468,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:113](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L113)
+[room.ts:113](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L113)
 
 ___
 
@@ -494,7 +494,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:81](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L81)
+[room.ts:81](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L81)
 
 ___
 
@@ -520,7 +520,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:132](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L132)
+[room.ts:132](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L132)
 
 ___
 
@@ -548,7 +548,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L239)
 
 ___
 
@@ -568,4 +568,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L214)

--- a/wiki/classes/internal.default-1.md
+++ b/wiki/classes/internal.default-1.md
@@ -63,7 +63,7 @@ Callbridge Room.
 
 #### Defined in
 
-[room.ts:73](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L73)
+[room.ts:73](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L73)
 
 ## Accessors
 
@@ -83,7 +83,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L255)
 
 ___
 
@@ -103,7 +103,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L248)
 
 ___
 
@@ -123,7 +123,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L262)
 
 ## Methods
 
@@ -146,7 +146,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:158](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L158)
+[room.ts:158](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L158)
 
 ___
 
@@ -181,7 +181,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L301)
 
 ___
 
@@ -203,7 +203,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:147](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L147)
+[room.ts:147](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L147)
 
 ___
 
@@ -236,7 +236,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L282)
 
 ___
 
@@ -269,7 +269,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L274)
 
 ___
 
@@ -303,7 +303,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L291)
 
 ___
 
@@ -332,7 +332,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L311)
 
 ___
 
@@ -354,7 +354,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:89](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L89)
+[room.ts:89](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L89)
 
 ___
 
@@ -376,7 +376,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:97](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L97)
+[room.ts:97](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L97)
 
 ___
 
@@ -398,7 +398,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:105](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L105)
+[room.ts:105](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L105)
 
 ___
 
@@ -420,7 +420,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L121)
+[room.ts:121](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L121)
 
 ___
 
@@ -442,7 +442,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:113](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L113)
+[room.ts:113](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L113)
 
 ___
 
@@ -464,7 +464,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:81](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L81)
+[room.ts:81](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L81)
 
 ___
 
@@ -486,7 +486,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:132](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L132)
+[room.ts:132](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/room.ts#L132)
 
 ___
 
@@ -514,7 +514,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L239)
 
 ___
 
@@ -534,4 +534,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L214)

--- a/wiki/classes/internal.default-1.md
+++ b/wiki/classes/internal.default-1.md
@@ -63,7 +63,7 @@ Callbridge Room.
 
 #### Defined in
 
-[room.ts:73](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L73)
+[room.ts:73](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L73)
 
 ## Accessors
 
@@ -83,7 +83,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:235](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L235)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
 
 ___
 
@@ -103,7 +103,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:228](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L228)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
 
 ___
 
@@ -123,7 +123,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:242](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L242)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
 
 ## Methods
 
@@ -146,7 +146,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:158](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L158)
+[room.ts:158](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L158)
 
 ___
 
@@ -181,7 +181,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:281](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L281)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
 
 ___
 
@@ -203,7 +203,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:147](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L147)
+[room.ts:147](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L147)
 
 ___
 
@@ -236,7 +236,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L262)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
 
 ___
 
@@ -269,7 +269,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:254](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L254)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
 
 ___
 
@@ -303,7 +303,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:271](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L271)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
 
 ___
 
@@ -332,7 +332,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L291)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
 
 ___
 
@@ -354,7 +354,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:89](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L89)
+[room.ts:89](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L89)
 
 ___
 
@@ -376,7 +376,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:97](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L97)
+[room.ts:97](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L97)
 
 ___
 
@@ -398,7 +398,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:105](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L105)
+[room.ts:105](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L105)
 
 ___
 
@@ -420,7 +420,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:121](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L121)
+[room.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L121)
 
 ___
 
@@ -442,7 +442,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:113](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L113)
+[room.ts:113](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L113)
 
 ___
 
@@ -464,7 +464,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:81](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L81)
+[room.ts:81](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L81)
 
 ___
 
@@ -486,7 +486,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:132](https://github.com/iotum/callbridge-js/blob/2066c52/src/room.ts#L132)
+[room.ts:132](https://github.com/iotum/callbridge-js/blob/5b639d5/src/room.ts#L132)
 
 ___
 
@@ -514,7 +514,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:219](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L219)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
 
 ___
 
@@ -534,4 +534,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:195](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L195)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)

--- a/wiki/classes/internal.default.md
+++ b/wiki/classes/internal.default.md
@@ -73,7 +73,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:164](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L164)
+[widget.ts:164](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L164)
 
 ## Properties
 
@@ -83,7 +83,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:144](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L144)
+[widget.ts:144](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L144)
 
 ## Accessors
 
@@ -99,7 +99,7 @@ The widget instance.
 
 #### Defined in
 
-[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L255)
 
 ___
 
@@ -115,7 +115,7 @@ Whether the widget is ready.
 
 #### Defined in
 
-[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L248)
 
 ___
 
@@ -131,7 +131,7 @@ The Window or WindowProxy instance of the widget.
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L262)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L301)
 
 ___
 
@@ -199,7 +199,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L282)
 
 ___
 
@@ -232,7 +232,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L274)
 
 ___
 
@@ -266,7 +266,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L291)
 
 ___
 
@@ -295,7 +295,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L311)
 
 ___
 
@@ -319,7 +319,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L239)
 
 ___
 
@@ -335,4 +335,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L214)

--- a/wiki/classes/internal.default.md
+++ b/wiki/classes/internal.default.md
@@ -73,7 +73,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:154](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L154)
+[widget.ts:164](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L164)
 
 ## Properties
 
@@ -83,7 +83,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:136](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L136)
+[widget.ts:144](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L144)
 
 ## Accessors
 
@@ -99,7 +99,7 @@ The widget instance.
 
 #### Defined in
 
-[widget.ts:235](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L235)
+[widget.ts:255](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L255)
 
 ___
 
@@ -115,7 +115,7 @@ Whether the widget is ready.
 
 #### Defined in
 
-[widget.ts:228](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L228)
+[widget.ts:248](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L248)
 
 ___
 
@@ -131,7 +131,7 @@ The Window or WindowProxy instance of the widget.
 
 #### Defined in
 
-[widget.ts:242](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L242)
+[widget.ts:262](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L262)
 
 ## Methods
 
@@ -166,7 +166,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:281](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L281)
+[widget.ts:301](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L301)
 
 ___
 
@@ -199,7 +199,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:262](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L262)
+[widget.ts:282](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L282)
 
 ___
 
@@ -232,7 +232,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:254](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L254)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L274)
 
 ___
 
@@ -266,7 +266,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:271](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L271)
+[widget.ts:291](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L291)
 
 ___
 
@@ -295,7 +295,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:291](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L291)
+[widget.ts:311](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L311)
 
 ___
 
@@ -319,7 +319,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:219](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L219)
+[widget.ts:239](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L239)
 
 ___
 
@@ -335,4 +335,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:195](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L195)
+[widget.ts:214](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L214)

--- a/wiki/enums/LayoutOption.md
+++ b/wiki/enums/LayoutOption.md
@@ -23,7 +23,7 @@ Full UI (default)
 
 #### Defined in
 
-[dashboard.ts:22](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L22)
+[dashboard.ts:22](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L22)
 
 ___
 
@@ -35,7 +35,7 @@ Only the list (sidebar), applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L24)
+[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L24)
 
 ___
 
@@ -47,7 +47,7 @@ Only the main content, applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L26)
+[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L26)
 
 ___
 
@@ -59,4 +59,4 @@ No UI
 
 #### Defined in
 
-[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L28)
+[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L28)

--- a/wiki/enums/LayoutOption.md
+++ b/wiki/enums/LayoutOption.md
@@ -23,7 +23,7 @@ Full UI (default)
 
 #### Defined in
 
-[dashboard.ts:22](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L22)
+[dashboard.ts:22](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L22)
 
 ___
 
@@ -35,7 +35,7 @@ Only the list (sidebar), applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L24)
+[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L24)
 
 ___
 
@@ -47,7 +47,7 @@ Only the main content, applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L26)
+[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L26)
 
 ___
 
@@ -59,4 +59,4 @@ No UI
 
 #### Defined in
 
-[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L28)
+[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L28)

--- a/wiki/enums/Service.md
+++ b/wiki/enums/Service.md
@@ -23,7 +23,7 @@ Contacts (Address Book)
 
 #### Defined in
 
-[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L14)
+[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L14)
 
 ___
 
@@ -35,7 +35,7 @@ Drive (Content Library)
 
 #### Defined in
 
-[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L12)
+[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L12)
 
 ___
 
@@ -47,7 +47,7 @@ None
 
 #### Defined in
 
-[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L8)
+[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L8)
 
 ___
 
@@ -59,4 +59,4 @@ Team (Chat)
 
 #### Defined in
 
-[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/2066c52/src/dashboard.ts#L10)
+[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L10)

--- a/wiki/enums/Service.md
+++ b/wiki/enums/Service.md
@@ -23,7 +23,7 @@ Contacts (Address Book)
 
 #### Defined in
 
-[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L14)
+[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L14)
 
 ___
 
@@ -35,7 +35,7 @@ Drive (Content Library)
 
 #### Defined in
 
-[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L12)
+[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L12)
 
 ___
 
@@ -47,7 +47,7 @@ None
 
 #### Defined in
 
-[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L8)
+[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L8)
 
 ___
 
@@ -59,4 +59,4 @@ Team (Chat)
 
 #### Defined in
 
-[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/5b639d5/src/dashboard.ts#L10)
+[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/dashboard.ts#L10)

--- a/wiki/interfaces/internal.WidgetEventEmitter.md
+++ b/wiki/interfaces/internal.WidgetEventEmitter.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[widget.ts:127](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L127)
+[widget.ts:127](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L127)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[widget.ts:125](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L125)
+[widget.ts:125](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L125)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[widget.ts:124](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L124)
+[widget.ts:124](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L124)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[widget.ts:126](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L126)
+[widget.ts:126](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L126)
 
 ___
 
@@ -157,4 +157,4 @@ ___
 
 #### Defined in
 
-[widget.ts:128](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L128)
+[widget.ts:128](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L128)

--- a/wiki/interfaces/internal.WidgetEventEmitter.md
+++ b/wiki/interfaces/internal.WidgetEventEmitter.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[widget.ts:119](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L119)
+[widget.ts:127](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L127)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[widget.ts:117](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L117)
+[widget.ts:125](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L125)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[widget.ts:116](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L116)
+[widget.ts:124](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L124)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[widget.ts:118](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L118)
+[widget.ts:126](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L126)
 
 ___
 
@@ -157,4 +157,4 @@ ___
 
 #### Defined in
 
-[widget.ts:120](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L120)
+[widget.ts:128](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L128)

--- a/wiki/modules/internal.md
+++ b/wiki/modules/internal.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[widget.ts:112](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L112)
+[widget.ts:120](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L120)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[widget.ts:111](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L111)
+[widget.ts:119](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L119)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[widget.ts:113](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L113)
+[widget.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L121)
 
 ___
 
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[widget.ts:49](https://github.com/iotum/callbridge-js/blob/2066c52/src/widget.ts#L49)
+[widget.ts:57](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L57)

--- a/wiki/modules/internal.md
+++ b/wiki/modules/internal.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[widget.ts:120](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L120)
+[widget.ts:120](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L120)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[widget.ts:119](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L119)
+[widget.ts:119](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L119)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[widget.ts:121](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L121)
+[widget.ts:121](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L121)
 
 ___
 
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[widget.ts:57](https://github.com/iotum/callbridge-js/blob/5b639d5/src/widget.ts#L57)
+[widget.ts:57](https://github.com/iotum/callbridge-js/blob/f54e7c1/src/widget.ts#L57)


### PR DESCRIPTION
- new `target.checkExisting` option to attach an existing popup widget
  - 1.5 sec timeout
  - the host app should cache data, e.g. room list, current room, etc. to ensure seamless experience
- fix
  - security error when re-using the target name (pop up)
  - some doc fixes