### PR TITLE
faster discovery when re-attaching existing widget

### DIFF
--- a/dist/widget.js
+++ b/dist/widget.js
@@ -99,6 +99,12 @@ export default class Widget {
                     this.once('widget.LOAD', resolve);
                     // existing widget pings every 1000ms
                     setTimeout(resolve, 1500);
+                    // broadcast a poke to all dangling widgets
+                    if ('BroadcastChannel' in self) {
+                        const channel = new BroadcastChannel('widget-channel');
+                        channel.postMessage(PING);
+                        channel.close();
+                    }
                 });
                 if (this._instance) {
                     // existing widget will emit READY event after the PONG

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@iotum/callbridge-js",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@iotum/callbridge-js",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "events": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@iotum/callbridge-js",
   "description": "Loading wrapper for Callbridge",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Iotum (https://www.iotum.com)",
   "license": "MIT",
   "homepage": "https://www.callbridge.com/",
@@ -17,6 +17,7 @@
     "client",
     "sdk"
   ],
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/__tests__/widget-test.ts
+++ b/src/__tests__/widget-test.ts
@@ -103,8 +103,16 @@ describe('widget', () => {
       });
 
       describe('re-attach popup widget', () => {
+        let broadcast: BroadcastChannel;
+
         beforeEach(() => {
           jest.useFakeTimers();
+
+          broadcast = {
+            postMessage: jest.fn(),
+            close: jest.fn(),
+          } as any;
+          self.BroadcastChannel = jest.fn().mockImplementation(() => broadcast);
 
           widget = new Widget(
             {
@@ -118,6 +126,11 @@ describe('widget', () => {
 
         it('waits for any existing widget', () => {
           expect(mockWindow.open).not.toHaveBeenCalled();
+        });
+
+        it('broadcasts a poke', () => {
+          expect(BroadcastChannel).toHaveBeenCalledWith('widget-channel');
+          expect(broadcast.postMessage).toHaveBeenCalledWith('_ping');
         });
 
         describe('found', () => {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -356,6 +356,12 @@ export default class Widget<
         this.once('widget.LOAD', resolve);
         // existing widget pings every 1000ms
         setTimeout(resolve, 1500);
+        // broadcast a poke to all dangling widgets
+        if ('BroadcastChannel' in self) {
+          const channel = new BroadcastChannel('widget-channel');
+          channel.postMessage(PING);
+          channel.close();
+        }
       });
 
       if (this._instance) {

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -45,7 +45,7 @@ Audio output settings.
 
 #### Defined in
 
-[room.ts:6](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L6)
+[room.ts:6](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L6)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[dashboard.ts:48](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L48)
+[dashboard.ts:48](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L48)
 
 ___
 
@@ -83,7 +83,7 @@ Livestream options.
 
 #### Defined in
 
-[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/709e3ef/src/livestream.ts#L6)
+[livestream.ts:6](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/livestream.ts#L6)
 
 ___
 
@@ -114,7 +114,7 @@ Meeting options.
 
 #### Defined in
 
-[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/709e3ef/src/meeting.ts#L7)
+[meeting.ts:7](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/meeting.ts#L7)
 
 ___
 
@@ -133,7 +133,7 @@ Dashboard service options.
 
 #### Defined in
 
-[dashboard.ts:36](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L36)
+[dashboard.ts:36](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L36)
 
 ___
 
@@ -160,4 +160,4 @@ Widget options.
 
 #### Defined in
 
-[widget.ts:9](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L9)
+[widget.ts:9](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L9)

--- a/wiki/classes/Dashboard.md
+++ b/wiki/classes/Dashboard.md
@@ -54,7 +54,7 @@ Callbridge Dashboard.
 
 #### Defined in
 
-[dashboard.ts:92](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L92)
+[dashboard.ts:92](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L92)
 
 ## Accessors
 
@@ -74,7 +74,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:267](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L267)
+[widget.ts:267](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L267)
 
 ___
 
@@ -94,7 +94,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:260](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L260)
+[widget.ts:260](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L260)
 
 ___
 
@@ -114,7 +114,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L274)
 
 ## Methods
 
@@ -149,7 +149,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:313](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L313)
+[widget.ts:313](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L313)
 
 ___
 
@@ -171,7 +171,7 @@ Loads a specific page from the session history.
 
 #### Defined in
 
-[dashboard.ts:137](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L137)
+[dashboard.ts:137](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L137)
 
 ___
 
@@ -194,7 +194,7 @@ Loads the service.
 
 #### Defined in
 
-[dashboard.ts:127](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L127)
+[dashboard.ts:127](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L127)
 
 ___
 
@@ -227,7 +227,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:294](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L294)
+[widget.ts:294](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L294)
 
 ___
 
@@ -260,7 +260,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:286](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L286)
+[widget.ts:286](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L286)
 
 ___
 
@@ -294,7 +294,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:303](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L303)
+[widget.ts:303](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L303)
 
 ___
 
@@ -323,7 +323,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:323](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L323)
+[widget.ts:323](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L323)
 
 ___
 
@@ -351,7 +351,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:251](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L251)
+[widget.ts:251](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L251)
 
 ___
 
@@ -371,4 +371,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:223](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L223)
+[widget.ts:223](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L223)

--- a/wiki/classes/Livestream.md
+++ b/wiki/classes/Livestream.md
@@ -52,7 +52,7 @@ Callbridge Livesteam Viewer.
 
 #### Defined in
 
-[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/709e3ef/src/livestream.ts#L28)
+[livestream.ts:28](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/livestream.ts#L28)
 
 ## Accessors
 
@@ -72,7 +72,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:267](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L267)
+[widget.ts:267](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L267)
 
 ___
 
@@ -92,7 +92,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:260](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L260)
+[widget.ts:260](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L260)
 
 ___
 
@@ -112,7 +112,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L274)
 
 ## Methods
 
@@ -147,7 +147,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:313](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L313)
+[widget.ts:313](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L313)
 
 ___
 
@@ -180,7 +180,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:294](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L294)
+[widget.ts:294](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L294)
 
 ___
 
@@ -213,7 +213,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:286](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L286)
+[widget.ts:286](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L286)
 
 ___
 
@@ -247,7 +247,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:303](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L303)
+[widget.ts:303](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L303)
 
 ___
 
@@ -276,7 +276,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:323](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L323)
+[widget.ts:323](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L323)
 
 ___
 
@@ -304,7 +304,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:251](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L251)
+[widget.ts:251](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L251)
 
 ___
 
@@ -324,4 +324,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:223](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L223)
+[widget.ts:223](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L223)

--- a/wiki/classes/Meeting.md
+++ b/wiki/classes/Meeting.md
@@ -61,7 +61,7 @@ Callbridge Meeting Room.
 
 #### Defined in
 
-[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/709e3ef/src/meeting.ts#L71)
+[meeting.ts:71](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/meeting.ts#L71)
 
 ## Accessors
 
@@ -81,7 +81,7 @@ Room.instance
 
 #### Defined in
 
-[widget.ts:267](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L267)
+[widget.ts:267](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L267)
 
 ___
 
@@ -101,7 +101,7 @@ Room.isReady
 
 #### Defined in
 
-[widget.ts:260](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L260)
+[widget.ts:260](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L260)
 
 ___
 
@@ -121,7 +121,7 @@ Room.wnd
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L274)
 
 ## Methods
 
@@ -148,7 +148,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:161](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L161)
+[room.ts:161](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L161)
 
 ___
 
@@ -183,7 +183,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:313](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L313)
+[widget.ts:313](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L313)
 
 ___
 
@@ -209,7 +209,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:150](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L150)
+[room.ts:150](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L150)
 
 ___
 
@@ -242,7 +242,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:294](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L294)
+[widget.ts:294](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L294)
 
 ___
 
@@ -275,7 +275,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:286](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L286)
+[widget.ts:286](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L286)
 
 ___
 
@@ -309,7 +309,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:303](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L303)
+[widget.ts:303](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L303)
 
 ___
 
@@ -338,7 +338,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:323](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L323)
+[widget.ts:323](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L323)
 
 ___
 
@@ -364,7 +364,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:92](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L92)
+[room.ts:92](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L92)
 
 ___
 
@@ -390,7 +390,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:100](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L100)
+[room.ts:100](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L100)
 
 ___
 
@@ -416,7 +416,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:108](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L108)
+[room.ts:108](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L108)
 
 ___
 
@@ -442,7 +442,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:124](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L124)
+[room.ts:124](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L124)
 
 ___
 
@@ -468,7 +468,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:116](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L116)
+[room.ts:116](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L116)
 
 ___
 
@@ -494,7 +494,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:84](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L84)
+[room.ts:84](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L84)
 
 ___
 
@@ -520,7 +520,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:135](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L135)
+[room.ts:135](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L135)
 
 ___
 
@@ -548,7 +548,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:251](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L251)
+[widget.ts:251](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L251)
 
 ___
 
@@ -568,4 +568,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:223](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L223)
+[widget.ts:223](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L223)

--- a/wiki/classes/internal.default-1.md
+++ b/wiki/classes/internal.default-1.md
@@ -63,7 +63,7 @@ Callbridge Room.
 
 #### Defined in
 
-[room.ts:76](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L76)
+[room.ts:76](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L76)
 
 ## Accessors
 
@@ -83,7 +83,7 @@ Widget.instance
 
 #### Defined in
 
-[widget.ts:267](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L267)
+[widget.ts:267](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L267)
 
 ___
 
@@ -103,7 +103,7 @@ Widget.isReady
 
 #### Defined in
 
-[widget.ts:260](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L260)
+[widget.ts:260](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L260)
 
 ___
 
@@ -123,7 +123,7 @@ Widget.wnd
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L274)
 
 ## Methods
 
@@ -146,7 +146,7 @@ Adjusts the audio output volume and/or stereo position of a remote participant.
 
 #### Defined in
 
-[room.ts:161](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L161)
+[room.ts:161](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L161)
 
 ___
 
@@ -181,7 +181,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:313](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L313)
+[widget.ts:313](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L313)
 
 ___
 
@@ -203,7 +203,7 @@ Mutes a remote participant, requires Moderator.
 
 #### Defined in
 
-[room.ts:150](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L150)
+[room.ts:150](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L150)
 
 ___
 
@@ -236,7 +236,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:294](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L294)
+[widget.ts:294](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L294)
 
 ___
 
@@ -269,7 +269,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:286](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L286)
+[widget.ts:286](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L286)
 
 ___
 
@@ -303,7 +303,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:303](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L303)
+[widget.ts:303](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L303)
 
 ___
 
@@ -332,7 +332,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:323](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L323)
+[widget.ts:323](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L323)
 
 ___
 
@@ -354,7 +354,7 @@ Manages the audio input device.
 
 #### Defined in
 
-[room.ts:92](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L92)
+[room.ts:92](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L92)
 
 ___
 
@@ -376,7 +376,7 @@ Manages the audio output device.
 
 #### Defined in
 
-[room.ts:100](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L100)
+[room.ts:100](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L100)
 
 ___
 
@@ -398,7 +398,7 @@ Manages my camera.
 
 #### Defined in
 
-[room.ts:108](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L108)
+[room.ts:108](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L108)
 
 ___
 
@@ -420,7 +420,7 @@ Manages incoming video.
 
 #### Defined in
 
-[room.ts:124](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L124)
+[room.ts:124](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L124)
 
 ___
 
@@ -442,7 +442,7 @@ Manages my microphone.
 
 #### Defined in
 
-[room.ts:116](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L116)
+[room.ts:116](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L116)
 
 ___
 
@@ -464,7 +464,7 @@ Manages the video input device.
 
 #### Defined in
 
-[room.ts:84](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L84)
+[room.ts:84](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L84)
 
 ___
 
@@ -486,7 +486,7 @@ Sets the global audio output volume.
 
 #### Defined in
 
-[room.ts:135](https://github.com/iotum/callbridge-js/blob/709e3ef/src/room.ts#L135)
+[room.ts:135](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/room.ts#L135)
 
 ___
 
@@ -514,7 +514,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:251](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L251)
+[widget.ts:251](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L251)
 
 ___
 
@@ -534,4 +534,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:223](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L223)
+[widget.ts:223](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L223)

--- a/wiki/classes/internal.default.md
+++ b/wiki/classes/internal.default.md
@@ -74,7 +74,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:170](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L170)
+[widget.ts:170](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L170)
 
 ## Properties
 
@@ -84,7 +84,7 @@ Callbridge Widget.
 
 #### Defined in
 
-[widget.ts:150](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L150)
+[widget.ts:150](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L150)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[widget.ts:148](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L148)
+[widget.ts:148](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L148)
 
 ## Accessors
 
@@ -110,7 +110,7 @@ The widget instance.
 
 #### Defined in
 
-[widget.ts:267](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L267)
+[widget.ts:267](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L267)
 
 ___
 
@@ -126,7 +126,7 @@ Whether the widget is ready.
 
 #### Defined in
 
-[widget.ts:260](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L260)
+[widget.ts:260](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L260)
 
 ___
 
@@ -142,7 +142,7 @@ The Window or WindowProxy instance of the widget.
 
 #### Defined in
 
-[widget.ts:274](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L274)
+[widget.ts:274](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L274)
 
 ## Methods
 
@@ -177,7 +177,7 @@ Returns true if the event had listeners, false otherwise.
 
 #### Defined in
 
-[widget.ts:313](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L313)
+[widget.ts:313](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L313)
 
 ___
 
@@ -210,7 +210,7 @@ Removes the specified `listener` from the listener array for the event named `ev
 
 #### Defined in
 
-[widget.ts:294](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L294)
+[widget.ts:294](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L294)
 
 ___
 
@@ -243,7 +243,7 @@ Adds the `listener` function to the end of the listeners array for the event nam
 
 #### Defined in
 
-[widget.ts:286](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L286)
+[widget.ts:286](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L286)
 
 ___
 
@@ -277,7 +277,7 @@ The next time eventName is triggered, this listener is removed and then invoked.
 
 #### Defined in
 
-[widget.ts:303](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L303)
+[widget.ts:303](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L303)
 
 ___
 
@@ -306,7 +306,7 @@ particularly when the instance was created by some other component or module.
 
 #### Defined in
 
-[widget.ts:323](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L323)
+[widget.ts:323](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L323)
 
 ___
 
@@ -330,7 +330,7 @@ Not available for pop-up.
 
 #### Defined in
 
-[widget.ts:251](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L251)
+[widget.ts:251](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L251)
 
 ___
 
@@ -346,4 +346,4 @@ Unloads the widget by removing the iframe or close the tab/window.
 
 #### Defined in
 
-[widget.ts:223](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L223)
+[widget.ts:223](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L223)

--- a/wiki/enums/LayoutOption.md
+++ b/wiki/enums/LayoutOption.md
@@ -23,7 +23,7 @@ Full UI (default)
 
 #### Defined in
 
-[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L24)
+[dashboard.ts:24](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L24)
 
 ___
 
@@ -35,7 +35,7 @@ Only the list (sidebar), applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L26)
+[dashboard.ts:26](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L26)
 
 ___
 
@@ -47,7 +47,7 @@ Only the main content, applicable to Team and Drive
 
 #### Defined in
 
-[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L28)
+[dashboard.ts:28](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L28)
 
 ___
 
@@ -59,4 +59,4 @@ No UI
 
 #### Defined in
 
-[dashboard.ts:30](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L30)
+[dashboard.ts:30](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L30)

--- a/wiki/enums/Service.md
+++ b/wiki/enums/Service.md
@@ -24,7 +24,7 @@ Contacts (Address Book)
 
 #### Defined in
 
-[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L14)
+[dashboard.ts:14](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L14)
 
 ___
 
@@ -36,7 +36,7 @@ Drive (Content Library)
 
 #### Defined in
 
-[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L12)
+[dashboard.ts:12](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L12)
 
 ___
 
@@ -48,7 +48,7 @@ Meet (Meetings)
 
 #### Defined in
 
-[dashboard.ts:16](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L16)
+[dashboard.ts:16](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L16)
 
 ___
 
@@ -60,7 +60,7 @@ None
 
 #### Defined in
 
-[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L8)
+[dashboard.ts:8](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L8)
 
 ___
 
@@ -72,4 +72,4 @@ Team (Chat)
 
 #### Defined in
 
-[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/709e3ef/src/dashboard.ts#L10)
+[dashboard.ts:10](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/dashboard.ts#L10)

--- a/wiki/interfaces/internal.WidgetEventEmitter.md
+++ b/wiki/interfaces/internal.WidgetEventEmitter.md
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[widget.ts:131](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L131)
+[widget.ts:131](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L131)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[widget.ts:129](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L129)
+[widget.ts:129](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L129)
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 #### Defined in
 
-[widget.ts:128](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L128)
+[widget.ts:128](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L128)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[widget.ts:130](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L130)
+[widget.ts:130](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L130)
 
 ___
 
@@ -157,4 +157,4 @@ ___
 
 #### Defined in
 
-[widget.ts:132](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L132)
+[widget.ts:132](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L132)

--- a/wiki/modules/internal.md
+++ b/wiki/modules/internal.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[widget.ts:124](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L124)
+[widget.ts:124](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L124)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[widget.ts:123](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L123)
+[widget.ts:123](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L123)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[widget.ts:125](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L125)
+[widget.ts:125](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L125)
 
 ___
 
@@ -94,4 +94,4 @@ ___
 
 #### Defined in
 
-[widget.ts:57](https://github.com/iotum/callbridge-js/blob/709e3ef/src/widget.ts#L57)
+[widget.ts:57](https://github.com/iotum/callbridge-js/blob/b63e1a9/src/widget.ts#L57)


### PR DESCRIPTION
do a broadcast to any existing widget to speed up the ping/pong.

still have the 1.5s delay if no existing widgets, when `checkExisting: true` is set.